### PR TITLE
Implement HTTP client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Added `Response.Validate()`
 - Added `Response.UnmarshalRequestID()`
 - Added `Error.MarshalData()` and `UnmarshalData()`
+- Added `BatchRequestMarshaler`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- Added `httptransport.Client`
 - Added `JSONRPCVersion` constant
 - Added `NewCallRequest()` and `NewNotifyRequest()`
 - Added `Request.ValidateClientSide()` and `RequestSet.ValidateClientSide()`

--- a/exchange.go
+++ b/exchange.go
@@ -124,15 +124,15 @@ func readRequestSet(
 	if readErr != nil {
 		if readErr == ctx.Err() {
 			// The context was canceled while waiting for the next request set,
-			// return the error to the caller without doing anything. The would be
-			// the typical path used to abort execution of a blocked call to
+			// return the error to the caller without doing anything. The would
+			// be the typical path used to abort execution of a blocked call to
 			// Exchange().
 			return RequestSet{}, false, readErr
 		}
 
 		if _, ok := readErr.(*Error); ok {
-			// There was no problem reading data for the request set, but it could
-			// not be parsed as JSON.
+			// There was no problem reading data for the request set, but it
+			// could not be parsed as JSON.
 			res := NewErrorResponse(nil, readErr)
 			l.LogError(res)
 

--- a/request.go
+++ b/request.go
@@ -389,7 +389,8 @@ type Validatable interface {
 
 // BatchRequestMarshaler marshals a batch of JSON-RPC requests to an io.Writer.
 type BatchRequestMarshaler struct {
-	Writer io.Writer
+	// Target is the target writer to which the JSON-RPC batch is marshaled.
+	Target io.Writer
 
 	encoder *json.Encoder
 	closed  bool
@@ -413,10 +414,10 @@ func (m *BatchRequestMarshaler) MarshalRequest(req Request) error {
 	if m.encoder != nil {
 		sep = comma
 	} else {
-		m.encoder = json.NewEncoder(m.Writer)
+		m.encoder = json.NewEncoder(m.Target)
 	}
 
-	if _, err := m.Writer.Write(sep); err != nil {
+	if _, err := m.Target.Write(sep); err != nil {
 		return err
 	}
 
@@ -426,7 +427,7 @@ func (m *BatchRequestMarshaler) MarshalRequest(req Request) error {
 // Close finishes writing the batch to m.Writer.
 //
 // If no requests have been marshaled, Close() is a no-op. This means that no
-// data will have been written to m.Writer at all.
+// data will have been written to m.Target at all.
 func (m *BatchRequestMarshaler) Close() error {
 	m.closed = true
 
@@ -434,7 +435,7 @@ func (m *BatchRequestMarshaler) Close() error {
 		return nil
 	}
 
-	if _, err := m.Writer.Write(closeArray); err != nil {
+	if _, err := m.Target.Write(closeArray); err != nil {
 		return err
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -753,7 +753,7 @@ var _ = Describe("type BatchRequestMarshaler", func() {
 	BeforeEach(func() {
 		buf = &bytes.Buffer{}
 		marshaler = &BatchRequestMarshaler{
-			Writer: buf,
+			Target: buf,
 		}
 
 		var err error
@@ -790,7 +790,7 @@ var _ = Describe("type BatchRequestMarshaler", func() {
 		})
 
 		It("returns an error if the marshaled request can not be written", func() {
-			marshaler.Writer = iotest.NewFailer(nil, nil)
+			marshaler.Target = iotest.NewFailer(nil, nil)
 
 			err := marshaler.MarshalRequest(req1)
 			Expect(err).To(MatchError(`<induced write error>`))
@@ -815,7 +815,7 @@ var _ = Describe("type BatchRequestMarshaler", func() {
 		It("returns an error if the closing bracket can not be written", func() {
 			err := marshaler.MarshalRequest(req1)
 
-			marshaler.Writer = iotest.NewFailer(nil, nil)
+			marshaler.Target = iotest.NewFailer(nil, nil)
 
 			err = marshaler.Close()
 			Expect(err).To(MatchError(`<induced write error>`))

--- a/request_test.go
+++ b/request_test.go
@@ -1,12 +1,14 @@
 package harpy_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
 	"strings"
 
 	. "github.com/dogmatiq/harpy"
+	"github.com/dogmatiq/iago/iotest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -737,6 +739,86 @@ var _ = Describe("type RequestSet", func() {
 					nil,
 				),
 			))
+		})
+	})
+})
+
+var _ = Describe("type BatchRequestMarshaler", func() {
+	var (
+		buf        *bytes.Buffer
+		marshaler  *BatchRequestMarshaler
+		req1, req2 Request
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		marshaler = &BatchRequestMarshaler{
+			Writer: buf,
+		}
+
+		var err error
+		req1, err = NewCallRequest(123, "<call>", []int{1, 2, 3})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		req2, err = NewNotifyRequest("<notify>", []int{4, 5, 6})
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	Describe("func MarshalRequest()", func() {
+		It("marshals requests into a batch", func() {
+			err := marshaler.MarshalRequest(req1)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = marshaler.MarshalRequest(req2)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = marshaler.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			rs, err := UnmarshalRequestSet(buf)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(rs.IsBatch).To(BeTrue())
+			Expect(rs.Requests).To(ContainElements(req1, req2))
+		})
+
+		It("returns an error if the request cannot be marshaled", func() {
+			req1.ID = json.RawMessage(`}`)
+
+			err := marshaler.MarshalRequest(req1)
+			Expect(err).To(MatchError(`json: error calling MarshalJSON for type json.RawMessage: invalid character '}' looking for beginning of value`))
+		})
+
+		It("returns an error if the marshaled request can not be written", func() {
+			marshaler.Writer = iotest.NewFailer(nil, nil)
+
+			err := marshaler.MarshalRequest(req1)
+			Expect(err).To(MatchError(`<induced write error>`))
+		})
+
+		It("panics if the marshaler has been closed", func() {
+			marshaler.Close()
+
+			Expect(func() {
+				marshaler.MarshalRequest(req1)
+			}).To(PanicWith("marshaler has been closed"))
+		})
+	})
+
+	Describe("func Close()", func() {
+		It("does not write anything if no requests have been written", func() {
+			err := marshaler.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buf.Bytes()).To(BeEmpty())
+		})
+
+		It("returns an error if the closing bracket can not be written", func() {
+			err := marshaler.MarshalRequest(req1)
+
+			marshaler.Writer = iotest.NewFailer(nil, nil)
+
+			err = marshaler.Close()
+			Expect(err).To(MatchError(`<induced write error>`))
 		})
 	})
 })

--- a/transport/httptransport/client.go
+++ b/transport/httptransport/client.go
@@ -233,7 +233,9 @@ func (c *Client) postSingleRequest(
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, body)
 	if err != nil {
-		return nil, err
+		// CODE COVERAGE: The main failure case for NewRequestWithContext() is
+		// an invalid HTTP method, but we hardcode it here.
+		panic(err)
 	}
 
 	httpReq.Header.Set("Content-Type", mediaType)

--- a/transport/httptransport/client.go
+++ b/transport/httptransport/client.go
@@ -1,0 +1,189 @@
+package httptransport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sync/atomic"
+
+	"github.com/dogmatiq/harpy"
+)
+
+// Client is a HTTP-based JSON-RPC client.
+type Client struct {
+	// HTTPClient is the HTTP client used to make requests. If it is nil,
+	// http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	// URL is the URL of the JSON-RPC server.
+	URL string
+
+	// prevID is the ID of the last "call" request sent. It is incremented by
+	// one to generate the next request ID.
+	prevID uint32 // atomic
+}
+
+// Call invokes a JSON-RPC method.
+func (c *Client) Call(
+	ctx context.Context,
+	method string,
+	params interface{},
+	result interface{},
+) error {
+	requestID := atomic.AddUint32(&c.prevID, 1)
+	req, err := harpy.NewCallRequest(
+		requestID,
+		method,
+		params,
+	)
+	if err != nil {
+		panic(fmt.Sprintf(
+			"unable to call JSON-RPC method (%s): %s",
+			method,
+			err,
+		))
+	}
+
+	if err := req.ValidateClientSide(); err != nil {
+		panic(fmt.Sprintf(
+			"unable to call JSON-RPC method (%s): %s",
+			method,
+			err.Message(),
+		))
+	}
+
+	if !validateResultParameter(result) {
+		panic(fmt.Sprintf(
+			"unable to call JSON-RPC method (%s): result must be a non-nil pointer",
+			method,
+		))
+	}
+
+	httpRes, err := c.postSingleRequest(ctx, req)
+	if err != nil {
+		return fmt.Errorf("unable to call JSON-RPC method (%s): %w", method, err)
+	}
+	defer httpRes.Body.Close()
+
+	res, err := c.unmarshalSingleResponse(requestID, httpRes)
+	if err != nil {
+		return fmt.Errorf("unable to process JSON-RPC response (%s): %w", method, err)
+	}
+
+	switch res := res.(type) {
+	case harpy.SuccessResponse:
+		if httpRes.StatusCode != http.StatusOK {
+			return fmt.Errorf(
+				"unable to process JSON-RPC response (%s): unexpected HTTP %d (%s) status code with JSON-RPC success response",
+				method,
+				httpRes.StatusCode,
+				http.StatusText(httpRes.StatusCode),
+			)
+		}
+
+		if err := json.Unmarshal(res.Result, result); err != nil {
+			return fmt.Errorf("unable to process JSON-RPC response (%s): unable to unmarshal result: %w", method, err)
+		}
+
+	case harpy.ErrorResponse:
+		return harpy.NewClientSideError(
+			res.Error.Code,
+			res.Error.Message,
+			res.Error.Data,
+		)
+	}
+
+	return nil
+}
+
+// unmarshalSingleResponse unmarshals a single (non-batched) JSON-RPC response
+// from a HTTP response.
+func (c *Client) unmarshalSingleResponse(
+	requestID uint32,
+	httpRes *http.Response,
+) (harpy.Response, error) {
+	if ct := httpRes.Header.Get("Content-Type"); ct != mediaType {
+		return nil, fmt.Errorf("unexpected content-type in HTTP response (%s)", ct)
+	}
+
+	rs, err := harpy.UnmarshalResponseSet(httpRes.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal JSON-RPC response: %w", err)
+	}
+
+	if rs.IsBatch {
+		return nil, errors.New("unexpected JSON-RPC batch response")
+	}
+
+	res := rs.Responses[0]
+	var requestIDInResponse uint32
+	if err := res.UnmarshalRequestID(&requestIDInResponse); err != nil {
+		return nil, errors.New("request ID in response is not an integer")
+	}
+
+	if requestIDInResponse != requestID {
+		return nil, fmt.Errorf(
+			"request ID in response (%d) does not match the actual request ID (%d)",
+			requestIDInResponse,
+			requestID,
+		)
+	}
+
+	return res, nil
+}
+
+// postSingleRequest sends a single (non-batched) request to the server.
+func (c *Client) postSingleRequest(
+	ctx context.Context,
+	req harpy.Request,
+) (*http.Response, error) {
+	body := &bytes.Buffer{}
+	if err := json.NewEncoder(body).Encode(req); err != nil {
+		// CODE COVERAGE: This should never fail as the request has already been
+		// validated.
+		panic(err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("Content-Type", mediaType)
+
+	hc := c.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+
+	res, err := hc.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// validateResultParameter returns true if r is a valid variable into which a
+// JSON-RPC result value can be written.
+func validateResultParameter(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+
+	rv := reflect.ValueOf(v)
+
+	if rv.Kind() != reflect.Ptr {
+		return false
+	}
+
+	if rv.IsNil() {
+		return false
+	}
+
+	return true
+}

--- a/transport/httptransport/client_test.go
+++ b/transport/httptransport/client_test.go
@@ -1,0 +1,280 @@
+package httptransport_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/dogmatiq/harpy"
+	. "github.com/dogmatiq/harpy/transport/httptransport"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Client", func() {
+	var (
+		ctx     context.Context
+		cancel  context.CancelFunc
+		router  harpy.Router
+		handler http.Handler
+		server  *httptest.Server
+		client  *Client
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+
+		router = harpy.Router{
+			"echo": func(
+				_ context.Context,
+				req harpy.Request,
+			) (interface{}, error) {
+				var params interface{}
+				err := req.UnmarshalParameters(&params)
+				return params, err
+			},
+			"error": func(
+				_ context.Context,
+				req harpy.Request,
+			) (interface{}, error) {
+				var params interface{}
+				if err := req.UnmarshalParameters(&params); err != nil {
+					return nil, err
+				}
+				return nil, harpy.NewError(
+					123,
+					harpy.WithMessage("<message>"),
+					harpy.WithData(params),
+				)
+			},
+		}
+
+		handler = &Handler{
+			Exchanger: router,
+		}
+
+		server = httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handler.ServeHTTP(w, r)
+			}),
+		)
+
+		client = &Client{
+			HTTPClient: server.Client(),
+			URL:        server.URL,
+		}
+	})
+
+	AfterEach(func() {
+		server.Close()
+		cancel()
+	})
+
+	Describe("func Call()", func() {
+		It("returns the JSON-RPC result", func() {
+			params := []int{1, 2, 3}
+			var result []int
+			err := client.Call(ctx, "echo", params, &result)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).To(Equal(params))
+		})
+
+		It("returns the JSON-RPC error produced by the server", func() {
+			params := []int{1, 2, 3}
+			var result interface{}
+			err := client.Call(ctx, "error", params, &result)
+			Expect(err).Should(HaveOccurred())
+			Expect(result).To(BeNil())
+
+			var rpcErr *harpy.Error
+			Expect(err).To(BeAssignableToTypeOf(rpcErr))
+
+			rpcErr = err.(*harpy.Error)
+			Expect(rpcErr.Code()).To(BeNumerically("==", 123))
+			Expect(rpcErr.Message()).To(Equal("<message>"))
+
+			var data []int
+			ok, err := rpcErr.UnmarshalData(&data)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(data).To(Equal(params))
+		})
+
+		It("returns an error if there is a network error", func() {
+			server.Close()
+
+			params := []int{1, 2, 3}
+			var result []int
+			err := client.Call(ctx, "echo", params, &result)
+			Expect(err).To(MatchError(
+				fmt.Sprintf(
+					`unable to call JSON-RPC method (echo): Post "%s": dial tcp %s: connect: connection refused`,
+					server.URL,
+					strings.TrimPrefix(server.URL, "http://"),
+				),
+			))
+		})
+
+		It("returns an error if the result cannot be unmarshaled", func() {
+			params := []int{1, 2, 3}
+			var result []string
+			err := client.Call(ctx, "echo", params, &result)
+			Expect(err).To(MatchError(
+				`unable to process JSON-RPC response (echo): unable to unmarshal result: json: cannot unmarshal number into Go value of type string`,
+			))
+		})
+
+		It("panics if the JSON-RPC request can not be built", func() {
+			Expect(func() {
+				var result interface{}
+				client.Call(
+					ctx,
+					"<method>",
+					make(chan struct{}),
+					&result,
+				)
+			}).To(PanicWith(
+				`unable to call JSON-RPC method (<method>): unable to marshal request parameters: json: unsupported type: chan struct {}`,
+			))
+		})
+
+		It("panics if the JSON-RPC request can not be validated", func() {
+			Expect(func() {
+				var result interface{}
+				client.Call(
+					ctx,
+					"<method>",
+					123,
+					&result,
+				)
+			}).To(PanicWith(
+				`unable to call JSON-RPC method (<method>): parameters must be an array, an object, or null`,
+			))
+		})
+
+		DescribeTable(
+			"it panics if the result variable is not a pointer",
+			func(result interface{}) {
+				Expect(func() {
+					client.Call(
+						ctx,
+						"<method>",
+						[]int{1, 2, 3},
+						result,
+					)
+				}).To(PanicWith(
+					`unable to call JSON-RPC method (<method>): result must be a non-nil pointer`,
+				))
+			},
+			Entry("nil interface", nil),
+			Entry("nil pointer", (*int)(nil)),
+			Entry("non-pointer", "<string>"),
+		)
+
+		When("the server exhibits produces an unexpected response", func() {
+			It("returns an error if the server responds with an unexpected content type", func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/plain")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("OK"))
+				})
+
+				params := []int{1, 2, 3}
+				var result []int
+				err := client.Call(ctx, "echo", params, &result)
+				Expect(err).To(MatchError("unable to process JSON-RPC response (echo): unexpected content-type in HTTP response (text/plain)"))
+			})
+
+			It("returns an error if the JSON-RPC response cannot be parsed", func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("{"))
+				})
+
+				params := []int{1, 2, 3}
+				var result []int
+				err := client.Call(ctx, "echo", params, &result)
+				Expect(err).To(MatchError("unable to process JSON-RPC response (echo): cannot unmarshal JSON-RPC response: unexpected EOF"))
+			})
+
+			It("returns an error if the JSON-RPC response is a batch", func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`[{
+						"jsonrpc": "2.0",
+						"id": 123,
+						"result": {}
+					}]`))
+				})
+
+				params := []int{1, 2, 3}
+				var result []int
+				err := client.Call(ctx, "echo", params, &result)
+				Expect(err).To(MatchError("unable to process JSON-RPC response (echo): unexpected JSON-RPC batch response"))
+			})
+
+			It("returns an error if server returns a JSON-RPC success with an unexpected HTTP status", func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(`{
+						"jsonrpc": "2.0",
+						"id": 1,
+						"result": {}
+					}`))
+				})
+
+				params := []int{1, 2, 3}
+				var result []int
+				err := client.Call(ctx, "echo", params, &result)
+				Expect(err).To(MatchError(
+					`unable to process JSON-RPC response (echo): unexpected HTTP 400 (Bad Request) status code with JSON-RPC success response`,
+				))
+			})
+
+			It("returns an error if server returns a JSON-RPC error response with a non-integer request ID", func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{
+						"jsonrpc": "2.0",
+						"id": "<id>",
+						"error": {}
+					}`))
+				})
+
+				params := []int{1, 2, 3}
+				var result []int
+				err := client.Call(ctx, "echo", params, &result)
+				Expect(err).To(MatchError(
+					`unable to process JSON-RPC response (echo): request ID in response is not an integer`,
+				))
+			})
+
+			It("returns an error if server returns a JSON-RPC success response with a mismatched request ID", func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{
+						"jsonrpc": "2.0",
+						"id": 123,
+						"result": {}
+					}`))
+				})
+
+				params := []int{1, 2, 3}
+				var result []int
+				err := client.Call(ctx, "echo", params, &result)
+				Expect(err).To(MatchError(
+					`unable to process JSON-RPC response (echo): request ID in response (123) does not match the actual request ID (1)`,
+				))
+			})
+		})
+	})
+})

--- a/transport/httptransport/client_test.go
+++ b/transport/httptransport/client_test.go
@@ -175,7 +175,7 @@ var _ = Describe("type Client", func() {
 			Entry("non-pointer", "<string>"),
 		)
 
-		When("the server exhibits produces an unexpected response", func() {
+		When("the server exhibits unexpected behavior", func() {
 			It("returns an error if the server responds with an unexpected content type", func() {
 				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.Header().Set("Content-Type", "text/plain")

--- a/transport/httptransport/client_test.go
+++ b/transport/httptransport/client_test.go
@@ -64,8 +64,7 @@ var _ = Describe("type Client", func() {
 		)
 
 		client = &Client{
-			HTTPClient: server.Client(),
-			URL:        server.URL,
+			URL: server.URL,
 		}
 	})
 

--- a/transport/httptransport/doc.go
+++ b/transport/httptransport/doc.go
@@ -1,3 +1,5 @@
-// Package httptransport provides a JSON-RPC transport based on a standard Go
-// http.Handler.
+// Package httptransport provides a simple HTTP-based JSON-RPC transport.
+//
+// Requests are sent by making an HTTP post request. The implementation
+// integrates with Go's native HTTP package.
 package httptransport


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `httptransport.Client` struct and some other ancillary code that helps implement clients.

This PR is a draft, I am yet to add:
- [x] `Notify()` method for sending JSON-RPC notifications
- [ ] `Batch()` method for making batch requests

#### Why make this change?

Although we don't currently have a need for a Go HTTP client for production use, we want a robust, well-behaved client we can use to test our server implementations.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
